### PR TITLE
Add ITIL 4 Foundation certification to Certifications section

### DIFF
--- a/src/Components/Certifications.jsx
+++ b/src/Components/Certifications.jsx
@@ -40,6 +40,13 @@ const Certifications = () => {
         <h3>Microsoft Certified: Azure AI Fundamentals</h3>
         <a href="#" target="_blank">View Certificate</a>
       </CertificationCard>
+      <CertificationCard>
+        <h3>ITIL 4 Foundation Certificate in IT Service Management</h3>
+        <p>PeopleCert</p>
+        <p>Issued Apr 2025 · Expires Apr 2028</p>
+        <p>Credential ID ITIL 4 Foundation Certificate in IT Service Management</p>
+        <a href="#" target="_blank">View Certificate</a>
+      </CertificationCard>
     </Section>
   );
 };


### PR DESCRIPTION
### Motivation
- Surface an additional professional credential in the portfolio's Certifications section so visitors can see the ITIL 4 Foundation entry.
- Include issuer, issuance/expiration dates and credential identifier to match other certificate entries.

### Description
- Updated `src/Components/Certifications.jsx` to add a new `CertificationCard` for:
  - `ITIL 4 Foundation Certificate in IT Service Management` (PeopleCert)
  - Displays `Issued Apr 2025 · Expires Apr 2028` and a credential ID line
  - Includes a `View Certificate` link placeholder
- No other files were modified.

### Testing
- Started the dev server with `npm start`; the project bundled and the server became reachable (server reported running and `curl -I http://localhost:1234` returned `200 OK`).
- Attempted an automated page screenshot using Playwright to verify the rendered changes; the Playwright script could not connect to the dev server (net::ERR_CONNECTION_REFUSED) during the capture attempts.
- No repository unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944bdd42ec4832fa233cf9432c09af4)