### PR TITLE
Link Azure AI certificate to Credly and use local ITIL image proof

### DIFF
--- a/src/Components/Certifications.jsx
+++ b/src/Components/Certifications.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import itilCertificate from '../images/itil-4-certificate.png';
 
 const Section = styled.section`
   padding: 4rem 0;
@@ -38,14 +39,22 @@ const Certifications = () => {
       <h2>Certifications</h2>
       <CertificationCard>
         <h3>Microsoft Certified: Azure AI Fundamentals</h3>
-        <a href="#" target="_blank">View Certificate</a>
+        <a
+          href="https://www.credly.com/badges/1755ae09-3878-4274-bb2d-88e292cd0b5b?source=linked_in_profile"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View Certificate
+        </a>
       </CertificationCard>
       <CertificationCard>
         <h3>ITIL 4 Foundation Certificate in IT Service Management</h3>
         <p>PeopleCert</p>
         <p>Issued Apr 2025 · Expires Apr 2028</p>
         <p>Credential ID ITIL 4 Foundation Certificate in IT Service Management</p>
-        <a href="#" target="_blank">View Certificate</a>
+        <a href={itilCertificate} target="_blank" rel="noreferrer">
+          View Certificate
+        </a>
       </CertificationCard>
     </Section>
   );


### PR DESCRIPTION
### Motivation
- Replace placeholder `#` certificate links with the requested proof sources so viewers can open the actual evidence.
- Use the local `itil-4-certificate.png` image for the ITIL 4 proof instead of an empty anchor.
- Ensure external links include appropriate security attributes.

### Description
- Imported the ITIL image into the component: `import itilCertificate from '../images/itil-4-certificate.png'`.
- Updated the Azure AI Fundamentals link to point to the Credly badge URL: `https://www.credly.com/badges/1755ae09-3878-4274-bb2d-88e292cd0b5b?source=linked_in_profile`.
- Updated the ITIL 4 "View Certificate" anchor to open the local image: `href={itilCertificate}`.
- Added `rel="noreferrer"` to anchors that open in a new tab for improved security.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944caae5508832faaeb6c6d9a24f042)